### PR TITLE
Linting and other fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ replace (
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.1.11-0.20190411181648-9d55346c2bde
 )
+
+go 1.13

--- a/pkg/controller/servicebindingrequest/custom_env_parser.go
+++ b/pkg/controller/servicebindingrequest/custom_env_parser.go
@@ -2,15 +2,18 @@ package servicebindingrequest
 
 import (
 	"bytes"
-	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 	"text/template"
+
+	"github.com/redhat-developer/service-binding-operator/pkg/apis/apps/v1alpha1"
 )
 
+// CustomEnvParser is responsible to interpolate a given CustomEnvMap containing templates.
 type CustomEnvParser struct {
 	EnvMap []v1alpha1.CustomEnvMap
 	Cache  map[string]interface{}
 }
 
+// NewCustomEnvParser returns a new CustomEnvParser.
 func NewCustomEnvParser(envMap []v1alpha1.CustomEnvMap, cache map[string]interface{}) *CustomEnvParser {
 	return &CustomEnvParser{
 		EnvMap: envMap,
@@ -18,6 +21,7 @@ func NewCustomEnvParser(envMap []v1alpha1.CustomEnvMap, cache map[string]interfa
 	}
 }
 
+// Parse interpolates and caches the templates in EnvMap.
 func (c *CustomEnvParser) Parse() (map[string]interface{}, error) {
 	data := make(map[string]interface{})
 	for _, v := range c.EnvMap {

--- a/pkg/controller/servicebindingrequest/retriever.go
+++ b/pkg/controller/servicebindingrequest/retriever.go
@@ -37,20 +37,20 @@ const (
 )
 
 // getNestedValue retrieve value from dotted key path
-func (r *Retriever) getNestedValue(key string, sectionMap interface{}) (string, error, interface{}) {
+func (r *Retriever) getNestedValue(key string, sectionMap interface{}) (string, interface{}, error) {
 	logger := r.logger.WithValues("Key", key, "SectionMap", sectionMap)
 	if !strings.Contains(key, ".") {
 		value, exists := sectionMap.(map[string]interface{})[key]
 		if !exists {
-			return "", fmt.Errorf("Can't find key '%s'", key), sectionMap
+			return "", sectionMap, fmt.Errorf("Can't find key '%s'", key)
 		}
-		return fmt.Sprintf("%v", value), nil, sectionMap
+		return fmt.Sprintf("%v", value), sectionMap, nil
 	}
 	attrs := strings.SplitN(key, ".", 2)
 	newSectionMap, exists := sectionMap.(map[string]interface{})[attrs[0]]
 	logger.Info("Section maps :  ")
 	if !exists {
-		return "", fmt.Errorf("Can't find '%v' section in CR", attrs), newSectionMap
+		return "", newSectionMap, fmt.Errorf("Can't find '%v' section in CR", attrs)
 	}
 	return r.getNestedValue(attrs[1], newSectionMap.(map[string]interface{}))
 }
@@ -67,7 +67,7 @@ func (r *Retriever) getCRKey(section string, key string) (string, interface{}, e
 		return "", sectionMap, fmt.Errorf("Can't find '%s' section in CR named '%s'", section, objName)
 	}
 
-	v, err, _ := r.getNestedValue(key, sectionMap)
+	v, _, err := r.getNestedValue(key, sectionMap)
 	for k, v := range sectionMap.(map[string]interface{}) {
 		if _, ok := r.cache[section]; !ok {
 			r.cache[section] = make(map[string]interface{})


### PR DESCRIPTION
- Clean comment related lint errors.
- Fix method signature: errors should typically the last return value.
- Add value to go.mod indicating the go version.